### PR TITLE
No "double" type in either json-schema or mongoose specifications Number unhandled

### DIFF
--- a/JsonSchemaGenerator.js
+++ b/JsonSchemaGenerator.js
@@ -75,7 +75,7 @@ JsonSchemaGenerator.prototype.generateProperties = function (schema) {
 
     // also called for mebedded
     if (schema.options && schema.options.versionKey) {
-        properties[schema.options.versionKey] = {type: "double", required: false}
+        properties[schema.options.versionKey] = {type: "number", required: false}
     }
 
     return properties;
@@ -105,10 +105,10 @@ JsonSchemaGenerator.prototype.generateBoolean = function (path, schema) {
     return property;
 }
 
-JsonSchemaGenerator.prototype.generateDouble = function (path, schema) {
+JsonSchemaGenerator.prototype.generateNumber = function (path, schema) {
     var property = {};
     this.setGeneralProperties(property, path);
-    property.type = "double";
+    property.type = "number";
     if (path.options.min) {
         property.min = path.options.min;
     }
@@ -117,6 +117,7 @@ JsonSchemaGenerator.prototype.generateDouble = function (path, schema) {
     }
     return property;
 }
+
 
 JsonSchemaGenerator.prototype.generateDate = function (path, schema) {
     var property = {};

--- a/test/GformSchemaGenerator.js
+++ b/test/GformSchemaGenerator.js
@@ -76,7 +76,7 @@ describe('GformSchemaGenerator', function () {
             return a.code == "embedded"
         })[0];
         expect(embedded.group.attributes[0]).to.have.property("code", "x");
-        expect(Object.keys(schema.attributes).length).to.be(12);
+        expect(Object.keys(schema.attributes).length).to.be(13);
         done();
     });
 });

--- a/test/JsonSchemaGenerator.js
+++ b/test/JsonSchemaGenerator.js
@@ -60,6 +60,12 @@ describe('JsonSchemaGenerator', function () {
         expect(property).to.have.property("type", "string");
         done();
     });
+    it('should generate number prop correctly', function (done) {
+        var property = generator.generateNumber(Vegetable.paths["number"]);
+        console.log(JSON.stringify(property));
+        expect(property).to.have.property("type", "number");
+        done();
+    });
     it('should find embeddeds', function (done) {
         var embeddeds = generator.findEmbeddeds(Vegetable);
         expect(embeddeds.embedded.length).to.be(2);
@@ -70,9 +76,9 @@ describe('JsonSchemaGenerator', function () {
         var schema = generator.generate(Vegetable);
         console.log(JSON.stringify(schema));
         expect(schema.properties._id).to.have.property("required",false);
-       expect(schema.properties.__v).to.have.property("type","double");
+        expect(schema.properties.__v).to.have.property("type","number");
         expect(schema.properties.embedded.properties).to.have.property("x");
-        expect(Object.keys(schema.properties).length).to.be(13);
+        expect(Object.keys(schema.properties).length).to.be(14);
         done();
     });
 });

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -10,6 +10,7 @@ var Vegetable = new Schema({
     lastname: String,
     great: Boolean,
     date: Date,
+    number: Number,
     label: {type: String, enum: ["my", "your"]},
     nicknames: [String],
     moreNicknames: [


### PR DESCRIPTION
I added functionality to handle the Number type from mongoose and generate the "number" type for json-schema. I did this simply by replacing the double type because it doesn't appear in either specification. I also added a test for the number type in the JsonSchemaGenerator.
